### PR TITLE
Standard ownership must be apache

### DIFF
--- a/trunk/sentastico/code/controller.ext.php
+++ b/trunk/sentastico/code/controller.ext.php
@@ -112,26 +112,6 @@ function UnZip($zipfile,$dest_dir,$site_domain,$dir_to_install){
     }
 }
 
-// Fix permissions of installed files since they will automatically be set to                       
-// the apache user and group                                                                        
-function fixPermissions($completedir){                                                         
-    $sysOS = php_uname('s');                                                                        
-    $zsudo = ctrl_options::GetOption('zsudo');                                                      
-                                                                                                    
-    switch($sysOS){                                                                                 
-        case 'Linux':                                                                               
-            exec("$zsudo chown -R ftpuser.ftpgroup " . $completedir);                               
-            exec("$zsudo chmod -R 777 " . $completedir);                                            
-        break;                                                                                      
-        case 'Unix':                                                                                
-            exec("$zsudo chown -R ftpuser:ftpgroup " . $completedir);                               
-            exec("$zsudo chmod -R 777 " . $completedir);                                            
-        break;                                                                                      
-        default:                                                                                    
-            //windows or incompilable operating system !!Do Nothing!!                               
-        break;                                                                                      
-    }                                                                                               
-}
 
 // Function to retrieve remote XML for update check
 function check_remote_xml($xmlurl,$destfile){

--- a/trunk/sentastico/code/controller.ext.php
+++ b/trunk/sentastico/code/controller.ext.php
@@ -111,7 +111,26 @@ function UnZip($zipfile,$dest_dir,$site_domain,$dir_to_install){
 		 return false;
     }
 }
+// Fix permissions of installed files since they will automatically be set to
+// the apache user and group
+function fixPermissions($completedir){
+    $sysOS = php_uname('s');
+    $zsudo = ctrl_options::GetOption('zsudo');
 
+    switch($sysOS){
+        case 'Linux':
+           // exec("$zsudo chown -R ftpuser.ftpgroup " . $completedir);
+            exec("$zsudo chmod -R 777 " . $completedir);
+        break;
+        case 'Unix':
+           // exec("$zsudo chown -R ftpuser:ftpgroup " . $completedir);
+            exec("$zsudo chmod -R 777 " . $completedir);
+        break;
+        default:
+            //windows or incompilable operating system !!Do Nothing!!
+        break;
+    }
+}
 
 // Function to retrieve remote XML for update check
 function check_remote_xml($xmlurl,$destfile){


### PR DESCRIPTION
The code you use to "correct"the ownership is bricking permissions. After installing a site with Sentastico the ownership is set to ftpuser and group. But that is not what Sentora uses. See Sentora installer:

_//Assign httpd user and group to all users that will be created
HTTP_UID=$(id -u "$HTTP_USER")
HTTP_GID=$(sed -nr "s/^$HTTP_GROUP:x:([0-9]+):._/\1/p" /etc/group)
mysql -u root -p"$mysqlpassword" -e "ALTER TABLE sentora_proftpd.ftpuser ALTER COLUMN uid SET DEFAULT $HTTP_UID"
mysql -u root -p"$mysqlpassword" -e "ALTER TABLE sentora_proftpd.ftpuser ALTER COLUMN gid SET DEFAULT $HTTP_GID"
sed -i "s|!SQL_MIN_ID!|$HTTP_UID|" $PANEL_CONF/proftpd/proftpd-mysql.conf*

Because your script changes it to a ftpuser and group, the website is accessble but not website self (openbase issues). If you install wordpress you can't update or install themes and so. When changed the file owners back to what sentora coded by default it works again.
